### PR TITLE
Create CI Build Test Script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby 2.6
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      - name: Install Bundle Dependencies 
+        run: bundle install
+
+      - name: Build
+        run: bundle exec jekyll build


### PR DESCRIPTION
Creates a GitHub actions script to test pull requests and the latest commit to make sure they build fine

Note: This won't spot things like markdown being formatted wrong because that will still build fine. Still useful for other things like YAML, bad includes, etc

Merge instead of #3 where I accidentally commented out the dependency install from a testing thing