### PR TITLE
Change CCT link to archive link and remove whitelist in guide

### DIFF
--- a/guides/whitelist.htm
+++ b/guides/whitelist.htm
@@ -14,17 +14,16 @@ redirect_from:
                     <p>The whitelist was created to increase security and to focus user's resources on active projects.</p>
 
                     <h5>Discussion</h5>
-                    <p><a href="https://cryptocurrencytalk.com/topic/29841-discussion-boinc-whitelist-monitoring/">CCT Whitelist thread</a></p>
-                    <p><a href="https://cryptocurrencytalk.com/forum/2436-projects/">Projects subforum</a></p>
+                    <p><a href="https://web.archive.org/web/20150416222027/cryptocointalk.com/topic/29841-discussion-boinc-whitelist-monitoring/">CCT Whitelist thread</a></p>
                 </div>
 
                 <div class="col-12 col-sm-8">
                     <h5>Please note:</h5>
                     <p>You will only be rewarded Gridcoin for whitelisted BOINC projects.</p>
                     <p>Any BOINC work done outside of the whitelisted BOINC projects will not be rewarded Gridcoin.</p>
-                    <p>Want a project whitelisted? <a href="https://cryptocurrencytalk.com/forum/2436-projects/">Create a thread about it</a>!
+                    <p>Want a project whitelisted? Ask about it on the <code>#whitelisting-committee</code> channel on the Gridcoin Discord! More details about adding a project to the whitelist can be found on the <a href="https://gridcoin.us/wiki/whitelist-process.html">whitelist process wiki page</a></p>
                     <p>You can check whitelisted project details on <a href="https://gridcoinstats.eu/project">Gridcoinstats</a>.</p>
-                    <p>The whitelist is verifiable within the Windows client (coming to Linux soon).</p>
+                    <p>The whitelist is verifiable on the wallet on the projects tab on the beacon menu or with the <code>listprojects</code> command</p>
                 </div>
             </div>
         </div>
@@ -40,164 +39,4 @@ redirect_from:
             </div>
         </div>
         <!--End of GRC Feature Section-->
-</section>
-
-<section class="whitelist-2">
-    <!-- BOINC Content -->
-    <div class="container">
-        <div class="row text-center">
-            <div class="col-12 d-none d-md-block">
-                <table class="table table-sm table-dark table-hover table-striped table-bordered">
-                    <thead>
-                        <tr>
-                            <th>
-                                Project
-                            </th>
-                            <th>
-                                Goal
-                            </th>
-                            <th>
-                                Sponsor
-                            </th>
-                            <th>
-                                CPU
-                            </th>
-                            <th>
-                                GPU
-                            </th>
-                            <th>
-                                Team
-                            </th>
-                            <th>
-                                Stats
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for project in site.data.whitelist.projects %}
-                            <tr>
-                                <td>
-                                    <a href="{{ project.link }}">{{ project.name }}</a>
-                                </td>
-                                <td>
-                                    {{ project.goal }}
-                                </td>
-                                <td>
-                                    {{ project.sponsor }}
-                                </td>
-                                <td>
-                                    {% if project.cpu == "yes" %}
-                                      ✔️
-                                    {% else %}
-                                      ❌
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if project.gpu == "yes" %}
-                                      ✔️
-                                    {% else %}
-                                      ❌
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    <a href="{{ project.team }}" title="Gridcoin Team Link">📊</a>
-                                </td>
-                                <td>
-                                    <a href="{{ project.stats }}" title="Project stats">📈</a>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-
-            <div class="col-12 d-none d-sm-block d-md-none">
-                <table class="table table-sm table-dark table-hover table-striped table-bordered">
-                    <thead>
-                        <tr>
-                            <th>
-                                Project
-                            </th>
-                            <th>
-                                Sponsor
-                            </th>
-                            <th>
-                                CPU
-                            </th>
-                            <th>
-                                GPU
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for project in site.data.whitelist.projects %}
-                            <tr>
-                                <td>
-                                    <a href="{{ project.link }}">{{ project.name }}</a>
-                                </td>
-                                <td>
-                                    {{ project.sponsor }}
-                                </td>
-                                <td>
-                                    {% if project.cpu == "yes" %}
-                                      ✔️
-                                    {% else %}
-                                      ❌
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if project.gpu == "yes" %}
-                                      ✔️
-                                    {% else %}
-                                      ❌
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-
-            <div class="col-12 d-sm-none">
-                <table class="table table-sm table-dark table-hover table-striped table-bordered">
-                    <thead>
-                        <tr>
-                            <th>
-                                Project
-                            </th>
-                            <th>
-                                CPU
-                            </th>
-                            <th>
-                                GPU
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for project in site.data.whitelist.projects %}
-                            <tr>
-                                <td>
-                                    <a href="{{ project.link }}">{{ project.name }}</a>
-                                </td>
-                                <td>
-                                    {% if project.cpu == "yes" %}
-                                      ✔️
-                                    {% else %}
-                                      ❌
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if project.gpu == "yes" %}
-                                      ✔️
-                                    {% else %}
-                                      ❌
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
 </section>


### PR DESCRIPTION
Since CCT no longer exists, I have replaced the link with a link to the webarchive. In addition, I have removed the (no longer up-to-date) whitelist in the guide. 