### PR TITLE
Fix wiki layout

### DIFF
--- a/_layouts/wiki.html
+++ b/_layouts/wiki.html
@@ -16,6 +16,7 @@
                                     {% if wikipage.layout == 'wiki'%}
                                       {% if page.url == wikipage.url %}
                                         {% assign current = 'active' %}
+                                        {% assign title = wikipage.title %}
                                       {% else %}
                                         {% assign current = '' %}
                                       {% endif %}
@@ -29,6 +30,10 @@
                           </div>
                     </div>
                     <div class="col-xl-9">
+                      <h1 class="echo-header">
+                        <span class="echo" aria-hidden="true">{{ title }}</span>
+                        {{ title }}
+                      </h1>
                       {{ content  }}
                     </div>
                 </div>

--- a/_layouts/wiki.html
+++ b/_layouts/wiki.html
@@ -8,18 +8,20 @@
             <div class="min-h-80 docs-container container">
                 <div class="row">
                     <div class="col-xl-3">
-                        <details class="docs-menu">
-                            <summary>Other Wiki Pages (click to view)</summary>
-                            <ul>
-                                {% for page in site.pages %}
-                                  {% if page.layout == 'wiki'%}
-                                    <li>
-                                      <a href="{{ page.url }}">{{ page.title }}</a>
-                                    </li>
-                                  {% endif %}
-                                {% endfor %}
-                            </ul>
-                        </details>
+                        <div class="docs-menu">
+                            <summary>Other Wiki Pages</summary>
+                            <nav>
+                              <ul>
+                                  {% for page in site.pages %}
+                                    {% if page.layout == 'wiki'%}
+                                      <li>
+                                        <a href="{{ page.url }}">{{ page.title }}</a>
+                                      </li>
+                                    {% endif %}
+                                  {% endfor %}
+                              </ul>
+                            </nav>
+                          </div>
                     </div>
                     <div class="col-xl-9">
                         {{ content  }}

--- a/_layouts/wiki.html
+++ b/_layouts/wiki.html
@@ -11,11 +11,16 @@
                         <div class="docs-menu">
                             <summary>Other Wiki Pages</summary>
                             <nav>
-                              <ul>
-                                  {% for page in site.pages %}
-                                    {% if page.layout == 'wiki'%}
-                                      <li>
-                                        <a href="{{ page.url }}">{{ page.title }}</a>
+                              <ul class="navbar-nav">
+                                  {% for wikipage in site.pages %}
+                                    {% if wikipage.layout == 'wiki'%}
+                                      {% if page.url == wikipage.url %}
+                                        {% assign current = 'active' %}
+                                      {% else %}
+                                        {% assign current = '' %}
+                                      {% endif %}
+                                      <li class="nav-item">
+                                        <a class="nav-link {{ current }}" href="{{ wikipage.url }}">{{ wikipage.title }}</a>
                                       </li>
                                     {% endif %}
                                   {% endfor %}
@@ -24,7 +29,7 @@
                           </div>
                     </div>
                     <div class="col-xl-9">
-                        {{ content  }}
+                      {{ content  }}
                     </div>
                 </div>
             </div>

--- a/_layouts/wiki.html
+++ b/_layouts/wiki.html
@@ -3,27 +3,31 @@
     {% include _head.htm %}
     <body>
         {% include _header.htm %}
-        <div class="min-h-80 docs-container container-fluid">
-            <div class="row">
-                <div class="col-xl-3">
-                    <details class="docs-menu">
-                        <summary>Other Wiki Pages (click to view)</summary>
-                        <ul>
-                            {% for page in site.pages %}
-                              {% if page.layout == 'wiki'%}
-                                <li>
-                                  <a href="{{ page.url }}">{{ page.title }}</a>
-                                </li>
-                              {% endif %}
-                            {% endfor %}
-                        </ul>
-                    </details>
-                </div>
-                <div class="col-xl-6">
-                    {{ content  }}
+        <main>
+          <section class="grc-bgcolor">
+            <div class="min-h-80 docs-container container">
+                <div class="row">
+                    <div class="col-xl-3">
+                        <details class="docs-menu">
+                            <summary>Other Wiki Pages (click to view)</summary>
+                            <ul>
+                                {% for page in site.pages %}
+                                  {% if page.layout == 'wiki'%}
+                                    <li>
+                                      <a href="{{ page.url }}">{{ page.title }}</a>
+                                    </li>
+                                  {% endif %}
+                                {% endfor %}
+                            </ul>
+                        </details>
+                    </div>
+                    <div class="col-xl-9">
+                        {{ content  }}
+                    </div>
                 </div>
             </div>
-        </div>
+          </section>
+        </main>
         {% include _footer.htm %}
 
         <!--   Core JS Files   -->

--- a/assets/css/gridcoin.css
+++ b/assets/css/gridcoin.css
@@ -1002,3 +1002,28 @@ footer {
     top: 50%;
     transform: translateY(-50%);
 }
+
+
+/**
+ * Wiki
+ */
+ .docs-container h2 {
+  font-size: 2rem;
+  font-weight: normal;
+}
+
+.docs-container h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.docs-menu {
+  margin-top: 0.5rem;
+}
+
+.docs-container pre {
+  border: 1px solid #bbcddb;
+  border-radius: 0.5rem; 
+  background-color: #e9edf1;
+  padding: 1rem;
+}

--- a/assets/css/gridcoin.css
+++ b/assets/css/gridcoin.css
@@ -1017,8 +1017,25 @@ footer {
   font-weight: 600;
 }
 
-.docs-menu {
-  margin-top: 0.5rem;
+.docs-menu > summary {
+  list-style: none;
+  padding: 0.5rem 0;
+  font-size: 1.2rem;
+}
+
+.docs-menu .nav-link {
+  padding: 0.3rem 0;
+}
+
+.docs-menu .nav-link.active {
+  color: var(--text-dark);
+  font-weight: 600;
+}
+
+@media (max-width: 991.98px) {
+  .docs-menu {
+    text-align: center;
+  }
 }
 
 .docs-container pre {


### PR DESCRIPTION
- Fix wiki page layout
- Keep sidebar menu open as we have enough space for it
- Apply css styles to the sidebar menu
- Add article title to the top of the page
- Style `pre` blocks

![image](https://user-images.githubusercontent.com/32429858/144054983-16ea01e3-4c46-4779-b514-2357a0f027a5.png)

There are still issues to address, although I want to keep PRs relatively small. This is a subset of the changes.